### PR TITLE
[Fixes #4] Stop reinitializing costly regex in stringutility

### DIFF
--- a/stringutility.go
+++ b/stringutility.go
@@ -1,32 +1,31 @@
 package fuzzy
 
 import (
-	"regexp"
 	"strings"
+	"unicode"
 )
 
-func Cleanse(s string, forceAscii bool) string {
-	s = strings.TrimSpace(s)
-	s = strings.ToLower(s)
-	if forceAscii {
+func Cleanse(s string, forceASCII bool) string {
+	if forceASCII {
 		s = ASCIIOnly(s)
 	}
-
-	r := regexp.MustCompile("[^\\p{L}\\p{N}]")
-	s = r.ReplaceAllString(s, " ")
-	return s
+	s = strings.TrimSpace(s)
+	rs := make([]rune, 0, len(s))
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) {
+			r = ' '
+		}
+		rs = append(rs, r)
+	}
+	return strings.ToLower(string(rs))
 }
 
 func ASCIIOnly(s string) string {
-	runes := []rune(s)
-	stripped := make([]rune, len(runes))
-
-	w := 0
-	for _, r := range runes {
-		if r < 128 {
-			stripped[w] = r
-			w++
+	b := make([]byte, 0, len(s))
+	for _, r := range s {
+		if r <= unicode.MaxASCII {
+			b = append(b, byte(r))
 		}
 	}
-	return string(stripped[0:w])
+	return string(b)
 }

--- a/stringutility_test.go
+++ b/stringutility_test.go
@@ -7,6 +7,7 @@ import (
 var asciiOnlyData = [][]interface{}{
 	{"one", "one"},
 	{"Țwo", "wo"},
+	{"three three!", "three three!"},
 	{"ǩƱ©", ""},
 	{"123ABC", "123ABC"},
 }


### PR DESCRIPTION
Was using regexp.MustCompile within a frequently invoked
method Cleanse. Since go does not cache these calls, it was
incurring a costly regex compilation each time Cleanse was
called. The other changes made in the stackoverflow post that
caught this issue seem to further improve performance by
about 10% on top of the massive gains from fixing this issue,
so incorporating those as well.