### PR TITLE
Better args handling for Dedup

### DIFF
--- a/process.go
+++ b/process.go
@@ -220,7 +220,7 @@ func Dedupe(sliceWithDupes []string, threshold *int, scorer func(string, string)
 		}
 		if len(filtered) == 1 {
 			extracted = append(extracted, filtered[0].Match)
-		} else {
+		} else if len(filtered) > 0 {
 			altPoints := alphaLengthSortPairs(filtered)
 			sort.Sort(altPoints)
 			extracted = append(extracted, altPoints[0].Match)

--- a/process.go
+++ b/process.go
@@ -194,28 +194,16 @@ func largestKMatchPairs(pairs MatchPairs, k int) MatchPairs {
 	return make(MatchPairs, 0)
 }
 
-func Dedupe(sliceWithDupes []string, args ...interface{}) ([]string, error) {
-	var scorer func(string, string) int
-	scorer = func(s1, s2 string) int {
-		return TokenSetRatio(s1, s2, true, true)
-	}
-	threshold := 70
+var defaultThreshold = 70
 
-	for i, arg := range args {
-		switch i {
-		case 0:
-			t, err := arg.(int)
-			if err {
-				return nil, errors.New("expected first optional argument to be an integer")
-			}
-			threshold = t
-		case 1:
-			s, err := arg.(func(string, string) int)
-			if err {
-				return nil, errors.New("expected second optional argument to be a function of the form f(string,string)->int")
-			}
-			scorer = s
+func Dedupe(sliceWithDupes []string, threshold *int, scorer func(string, string) int) ([]string, error) {
+	if scorer == nil {
+		scorer = func(s1, s2 string) int {
+			return TokenSetRatio(s1, s2, true, true)
 		}
+	}
+	if threshold == nil {
+		threshold = &defaultThreshold
 	}
 
 	extracted := []string{}
@@ -226,7 +214,7 @@ func Dedupe(sliceWithDupes []string, args ...interface{}) ([]string, error) {
 		}
 		filtered := MatchPairs{}
 		for _, m := range matches {
-			if m.Score > threshold {
+			if m.Score > *threshold {
 				filtered = append(filtered, m)
 			}
 		}

--- a/process_test.go
+++ b/process_test.go
@@ -1,6 +1,7 @@
 package fuzzy
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -97,15 +98,44 @@ func TestExtractOne(t *testing.T) {
 
 func TestDedupe(t *testing.T) {
 	sliceWithDupes := []string{"Frodo Baggins", "Tom Sawyer", "Bilbo Baggin", "Samuel L. Jackson", "F. Baggins", "Frody Baggins", "Bilbo Baggins"}
-	res, _ := Dedupe(sliceWithDupes)
+	res, err := Dedupe(sliceWithDupes, nil, nil)
+	assert.Nil(t, err)
 	if len(res) >= len(sliceWithDupes) {
 		t.Error("expecting Dedupe to remove at least one string from slice")
 	}
 
 	sliceWithoutDupes := []string{"Tom", "Dick", "Harry"}
-	res2, _ := Dedupe(sliceWithoutDupes)
+	res2, err := Dedupe(sliceWithoutDupes, nil, nil)
+	assert.Nil(t, err)
 	if len(res2) != len(sliceWithoutDupes) {
 		t.Error("not expecting Dedupe to remove any strings from slice")
+	}
+
+	lowThreshold := 1
+	res3, err := Dedupe(sliceWithDupes, &lowThreshold, nil)
+	assert.Nil(t, err)
+	if len(res3) != 1 {
+		t.Error("expecting low threshold to dedupe all items")
+	}
+
+	highThreshold := 99
+	res4, err := Dedupe(sliceWithDupes, &highThreshold, nil)
+	assert.Nil(t, err)
+	if len(res4) != len(sliceWithDupes) {
+		t.Error("expecting high threshold to maintain all items")
+	}
+
+	threshold := 1
+	res5, err := Dedupe(sliceWithDupes, &threshold, func(s1 string, s2 string) int {
+		diff := len(s1) - len(s2)
+		if diff < 0 {
+			diff *= -1
+		}
+		return diff
+	})
+	assert.Nil(t, err)
+	if len(res5) != 2 {
+		t.Error("expecting custom scorer to yield two results")
 	}
 }
 


### PR DESCRIPTION
the original code has a bug, the cast check is flipped:

```go
t, err := arg.(int)
if err ...
```

should be

```go
t, ok := arg.(int)
if !ok ...
```

But anyway changed to a more go styled code